### PR TITLE
modified the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 
 1. `sudo apt-get install vim-gnome exuberant-ctags` [其他非 Debian 系的 Linux 请使用其自己的包管理器进行安装]
 2. 删除个人主目录下的 .vim 文件夹和 .vimrc 文件，如果没有则不需要执行删除动作 [使用命令 `rm -rf ~/.vim ~/.vimrc`，请注意备份]
-3. 使用 Git 将本项目拷贝到个人主目录下，取代已删文件的位置，然后将 vimfiles、_vimrc 改名为 .vim、.vimrc [命令为 `git clone https://github.com/ruchee/vimrc.git`、`mv vimfiles .vim`、`mv _vimrc .vimrc`]（也可以点击本页面的 Download ZIP 按钮下载）
+3. 使用 Git 将本项目的子目录拷贝到个人主目录下，取代已删文件的位置，然后将 vimfiles、_vimrc 改名为 .vim、.vimrc [命令为 `git clone https://github.com/ruchee/vimrc.git`、`mv vimfiles .vim`、`mv _vimrc .vimrc`]（也可以点击本页面的 Download ZIP 按钮下载）
 4. 可上 `https://github.com/ruchee/backup/blob/master/download/MONACO.TTF?raw=true` 下载 Monaco 字体，下载后使用命令 `mv MONACO.TTF ~/.fonts` 将其丢到 `~/.fonts` 目录即可
 5. 使用任意文本编辑器打开 .vimrc，将名字、邮箱、网址等全部替换为你自己的信息，如遇路径不同也全部替换为你本机的实际路径
 6. 如此这般就配置好了，尽情享受编码的乐趣吧，使用说明全部集中在 .vimrc 文件的头部，配置的后半部分全是各插件的具体配置项，初学无需理会
@@ -46,7 +46,7 @@
 ### 注意事项
 
 1. `Windows` 下需要的软件：gvim、ctags
-2. `Linux` 下需要的包文件：vim-gnome、exuberant-ctags
+2. `Linux` 下需要的包文件：vim-gtk、exuberant-ctags
 3. `Linux` 下必须使用 GUI 界面，否则 Meta 系按键将失效，可在 .bashrc 文件里面写入这么一行：`alias vim='gvim'`
 4. 配置文件前面部分的 tags、path 路径是我本人开发所用，你可以将其删除，也可以替换成自己的工程路径 [你需要先用 ctags 生成 tags 文件]
 5. 可使用这两条命令使 Linux、Cygwin 以及 Windows 共用同一套配置 [当然，这儿假设你安装的是双系统]：`ln -s your_gvim_path/vimfiles ~/.vim`、`ln -s your_gvim_path/_vimrc ~/.vimrc`


### PR DESCRIPTION
改了两个小地方：
1. 在使用指南的linux部分，如果按照上一个版本的README.md指南安装，使用不了。
2. 当使用vim-gnome是，尽管可以正常使用，启动时会报错。解决方法是安装vim-gtk。
（在台式机和笔记本的 ubuntu14.04上测试过）
